### PR TITLE
updated page builder to add new previews

### DIFF
--- a/studio/schemas/documents/page.js
+++ b/studio/schemas/documents/page.js
@@ -1,4 +1,5 @@
 import { GoBrowser } from "react-icons/go";
+import PageBuilderInput from "../../src/components/PageBuilderInput";
 
 const isJoinPage = (document) =>
   document?._id === 'join' || document?._id === 'drafts.join'
@@ -19,6 +20,9 @@ export default {
       type: 'array',
       title: 'Page sections',
       description: 'Add, edit, and reorder sections',
+      components: {
+        input: PageBuilderInput,
+      },
       hidden: ({ document }) => isJoinPage(document),
       of: [
         { type: 'uiComponentRef' },

--- a/studio/src/components/PageBuilderInput.jsx
+++ b/studio/src/components/PageBuilderInput.jsx
@@ -1,0 +1,263 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { AddIcon } from "@sanity/icons";
+import { randomKey } from "@sanity/util/content";
+import { Box, Button, Card, Dialog, Flex, Grid, Heading, Stack, Text } from "@sanity/ui";
+import { ArrayOfObjectsInput } from "sanity";
+
+const PREVIEW_ROOT = "/static/page-builder";
+const PREVIEW_EXTENSIONS = ["svg", "png", "webp", "jpg", "jpeg"];
+
+const SECTION_METADATA = {
+  uiComponentRef: {
+    description: "Insert a reusable UI reference by name.",
+  },
+  hero: {
+    description: "Large hero area with image, text, and CTA.",
+  },
+  heroCarousel: {
+    description: "Multiple hero slides displayed as a carousel.",
+  },
+  ctaPlug: {
+    description: "Callout section with copy and action buttons.",
+  },
+  zundfolgeLatest: {
+    description: "Latest Zundfolge issue teaser block.",
+  },
+  upcomingEvents: {
+    description: "Upcoming events feed with configurable limit.",
+  },
+  homepageSponsors: {
+    description: "Partner and sponsor logo section.",
+  },
+  headerBar: {
+    description: "Simple section header or divider block.",
+  },
+  pageContent: {
+    description: "Rich text content section for general page copy.",
+  },
+  advertisement: {
+    description: "Ad placement block for sponsorship inventory.",
+  },
+};
+
+const getPreviewSources = (schemaType) => {
+  const customPreviewPath =
+    schemaType?.options?.pageBuilderPreviewImage ||
+    schemaType?.options?.pageBuilder?.previewImage;
+
+  if (customPreviewPath) {
+    return [customPreviewPath];
+  }
+
+  return PREVIEW_EXTENSIONS.map(
+    (extension) => `${PREVIEW_ROOT}/${schemaType.name}.${extension}`
+  );
+};
+
+const getVisibleSchemaTypes = (schemaTypes = []) =>
+  schemaTypes.filter((schemaType) => schemaType && schemaType.hidden !== true);
+
+const PreviewImage = ({ schemaType }) => {
+  const sources = useMemo(() => getPreviewSources(schemaType), [schemaType]);
+  const [sourceIndex, setSourceIndex] = useState(0);
+  const Icon = schemaType.icon;
+  const currentSource = sources[sourceIndex];
+
+  if (!currentSource) {
+    return (
+      <FallbackPreview
+        icon={Icon}
+        title={schemaType.title || schemaType.name}
+        name={schemaType.name}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={currentSource}
+      alt={schemaType.title || schemaType.name}
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "block",
+        objectFit: "cover",
+        borderRadius: "6px",
+      }}
+      onError={() => setSourceIndex((index) => index + 1)}
+    />
+  );
+};
+
+const FallbackPreview = ({ icon: Icon, title, name }) => (
+  <Flex
+    align="center"
+    justify="center"
+    direction="column"
+    gap={3}
+    style={{
+      width: "100%",
+      height: "100%",
+      borderRadius: "6px",
+      background:
+        "linear-gradient(135deg, rgba(28, 39, 56, 0.12), rgba(28, 39, 56, 0.03))",
+      border: "1px solid rgba(28, 39, 56, 0.12)",
+    }}
+  >
+    {Icon ? (
+      <Box style={{ fontSize: "1.5rem", lineHeight: 0 }}>
+        <Icon />
+      </Box>
+    ) : null}
+    <Stack space={2}>
+      <Text align="center" size={1} weight="semibold">
+        {title}
+      </Text>
+      <Text align="center" muted size={0}>
+        {name}
+      </Text>
+    </Stack>
+  </Flex>
+);
+
+const PreviewCard = ({ schemaType, onSelect }) => {
+  const title = schemaType.title || schemaType.name;
+  const description =
+    SECTION_METADATA[schemaType.name]?.description || schemaType.name;
+  const Icon = schemaType.icon;
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onSelect(schemaType);
+      }
+    },
+    [onSelect, schemaType]
+  );
+
+  return (
+    <Card
+      as="button"
+      border
+      padding={3}
+      radius={3}
+      shadow={1}
+      tone="default"
+      onClick={() => onSelect(schemaType)}
+      onKeyDown={handleKeyDown}
+      style={{
+        width: "100%",
+        textAlign: "left",
+        cursor: "pointer",
+        background: "transparent",
+        height: "100%",
+      }}
+    >
+      <Stack space={3}>
+        <Box
+          style={{
+            width: "100%",
+            minHeight: "180px",
+            aspectRatio: "16 / 9",
+          }}
+        >
+          <PreviewImage schemaType={schemaType} />
+        </Box>
+        <Stack space={2}>
+          <Flex align="center" gap={2}>
+            {Icon ? (
+              <Box style={{ fontSize: "1rem", lineHeight: 0 }}>
+                <Icon />
+              </Box>
+            ) : null}
+            <Heading as="h3" size={1}>
+              {title}
+            </Heading>
+          </Flex>
+          <Text muted size={1}>
+            {description}
+          </Text>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+};
+
+const PageBuilderInput = (props) => {
+  const { onInsert, readOnly, schemaType } = props;
+  const [isDialogOpen, setDialogOpen] = useState(false);
+
+  const sectionTypes = useMemo(
+    () => getVisibleSchemaTypes(schemaType.of),
+    [schemaType.of]
+  );
+
+  const openDialog = useCallback(() => setDialogOpen(true), []);
+  const closeDialog = useCallback(() => setDialogOpen(false), []);
+
+  const handleSelect = useCallback(
+    (selectedSchemaType) => {
+      onInsert({
+        items: [
+          {
+            _type: selectedSchemaType.name,
+            _key: randomKey(12),
+          },
+        ],
+        position: "after",
+        referenceItem: -1,
+        open: true,
+      });
+      closeDialog();
+    },
+    [closeDialog, onInsert]
+  );
+
+  const renderArrayFunctions = useCallback(
+    () => (
+      <Button
+        mode="ghost"
+        icon={AddIcon}
+        text="Add section"
+        onClick={openDialog}
+        disabled={readOnly}
+      />
+    ),
+    [openDialog, readOnly]
+  );
+
+  return (
+    <>
+      <ArrayOfObjectsInput {...props} arrayFunctions={renderArrayFunctions} />
+      {isDialogOpen ? (
+        <Dialog
+          id="page-builder-section-selector"
+          header="Select a page section"
+          width={5}
+          zOffset={1000}
+          onClose={closeDialog}
+        >
+          <Box padding={4}>
+            <Stack space={4}>
+              <Text muted size={1}>
+                Choose a section type to insert into the page builder.
+              </Text>
+              <Grid columns={[1, 1, 2, 3]} gap={3}>
+                {sectionTypes.map((sectionType) => (
+                  <PreviewCard
+                    key={sectionType.name}
+                    schemaType={sectionType}
+                    onSelect={handleSelect}
+                  />
+                ))}
+              </Grid>
+            </Stack>
+          </Box>
+        </Dialog>
+      ) : null}
+    </>
+  );
+};
+
+export default PageBuilderInput;

--- a/studio/static/page-builder/advertisement.svg
+++ b/studio/static/page-builder/advertisement.svg
@@ -1,0 +1,7 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F4F7FA"/>
+  <rect x="34" y="56" width="252" height="68" rx="14" fill="#FFFFFF" stroke="#CBD8E3" stroke-width="2"/>
+  <rect x="54" y="74" width="74" height="32" rx="10" fill="#F0A429"/>
+  <rect x="146" y="76" width="112" height="12" rx="6" fill="#193B63"/>
+  <rect x="146" y="96" width="92" height="10" rx="5" fill="#D0DCE7"/>
+</svg>

--- a/studio/static/page-builder/ctaPlug.svg
+++ b/studio/static/page-builder/ctaPlug.svg
@@ -1,0 +1,10 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F4F8FC"/>
+  <rect x="28" y="28" width="264" height="124" rx="18" fill="#183A60"/>
+  <rect x="50" y="52" width="48" height="12" rx="6" fill="#F0A429"/>
+  <rect x="50" y="74" width="148" height="16" rx="8" fill="#FFFFFF"/>
+  <rect x="50" y="98" width="186" height="10" rx="5" fill="#AFC2D5"/>
+  <rect x="50" y="114" width="166" height="10" rx="5" fill="#AFC2D5"/>
+  <rect x="50" y="126" width="58" height="16" rx="8" fill="#F0A429"/>
+  <rect x="116" y="126" width="58" height="16" rx="8" fill="#FFFFFF"/>
+</svg>

--- a/studio/static/page-builder/headerBar.svg
+++ b/studio/static/page-builder/headerBar.svg
@@ -1,0 +1,6 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F5F7FA"/>
+  <rect x="28" y="72" width="264" height="36" rx="18" fill="#FFFFFF" stroke="#CBD8E3" stroke-width="2"/>
+  <rect x="50" y="84" width="112" height="12" rx="6" fill="#193B63"/>
+  <rect x="178" y="88" width="92" height="4" rx="2" fill="#D5E0EA"/>
+</svg>

--- a/studio/static/page-builder/hero.svg
+++ b/studio/static/page-builder/hero.svg
@@ -1,0 +1,11 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#EEF3F8"/>
+  <rect x="20" y="20" width="280" height="140" rx="18" fill="#FFFFFF" stroke="#CAD6E2" stroke-width="2"/>
+  <rect x="38" y="42" width="54" height="14" rx="7" fill="#F0A429"/>
+  <rect x="38" y="68" width="112" height="18" rx="9" fill="#193B63"/>
+  <rect x="38" y="92" width="98" height="18" rx="9" fill="#193B63"/>
+  <rect x="38" y="122" width="68" height="18" rx="9" fill="#F0A429"/>
+  <rect x="170" y="36" width="112" height="108" rx="14" fill="#D7E2ED"/>
+  <path d="M182 124L218 84L239 105L258 88L282 124V130H182V124Z" fill="#84A4C1"/>
+  <circle cx="215" cy="66" r="12" fill="#FFFFFF"/>
+</svg>

--- a/studio/static/page-builder/heroCarousel.svg
+++ b/studio/static/page-builder/heroCarousel.svg
@@ -1,0 +1,13 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#EEF3F8"/>
+  <rect x="26" y="32" width="120" height="96" rx="14" fill="#FFFFFF" stroke="#CAD6E2" stroke-width="2"/>
+  <rect x="100" y="22" width="120" height="96" rx="14" fill="#F8FBFD" stroke="#CAD6E2" stroke-width="2"/>
+  <rect x="174" y="32" width="120" height="96" rx="14" fill="#FFFFFF" stroke="#CAD6E2" stroke-width="2"/>
+  <rect x="118" y="42" width="46" height="10" rx="5" fill="#F0A429"/>
+  <rect x="118" y="60" width="74" height="12" rx="6" fill="#193B63"/>
+  <rect x="118" y="78" width="62" height="12" rx="6" fill="#193B63"/>
+  <rect x="118" y="98" width="48" height="12" rx="6" fill="#F0A429"/>
+  <circle cx="144" cy="148" r="6" fill="#193B63"/>
+  <circle cx="160" cy="148" r="6" fill="#F0A429"/>
+  <circle cx="176" cy="148" r="6" fill="#193B63" fill-opacity="0.3"/>
+</svg>

--- a/studio/static/page-builder/homepageSponsors.svg
+++ b/studio/static/page-builder/homepageSponsors.svg
@@ -1,0 +1,12 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F4F7FA"/>
+  <rect x="28" y="36" width="264" height="108" rx="16" fill="#FFFFFF" stroke="#CBD8E3" stroke-width="2"/>
+  <rect x="50" y="58" width="46" height="22" rx="8" fill="#193B63" fill-opacity="0.85"/>
+  <rect x="112" y="58" width="46" height="22" rx="8" fill="#F0A429"/>
+  <rect x="174" y="58" width="46" height="22" rx="8" fill="#193B63" fill-opacity="0.55"/>
+  <rect x="236" y="58" width="32" height="22" rx="8" fill="#9BB2C7"/>
+  <rect x="50" y="96" width="32" height="22" rx="8" fill="#9BB2C7"/>
+  <rect x="96" y="96" width="54" height="22" rx="8" fill="#193B63" fill-opacity="0.7"/>
+  <rect x="166" y="96" width="40" height="22" rx="8" fill="#F0A429"/>
+  <rect x="220" y="96" width="48" height="22" rx="8" fill="#193B63" fill-opacity="0.4"/>
+</svg>

--- a/studio/static/page-builder/pageContent.svg
+++ b/studio/static/page-builder/pageContent.svg
@@ -1,0 +1,9 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F3F6FA"/>
+  <rect x="42" y="30" width="236" height="18" rx="9" fill="#193B63"/>
+  <rect x="42" y="64" width="236" height="10" rx="5" fill="#CBD7E2"/>
+  <rect x="42" y="82" width="228" height="10" rx="5" fill="#CBD7E2"/>
+  <rect x="42" y="100" width="236" height="10" rx="5" fill="#CBD7E2"/>
+  <rect x="42" y="118" width="192" height="10" rx="5" fill="#CBD7E2"/>
+  <rect x="42" y="142" width="74" height="16" rx="8" fill="#F0A429"/>
+</svg>

--- a/studio/static/page-builder/uiComponentRef.svg
+++ b/studio/static/page-builder/uiComponentRef.svg
@@ -1,0 +1,11 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F3F7FB"/>
+  <rect x="28" y="28" width="264" height="124" rx="16" fill="#FFFFFF" stroke="#C6D4E1" stroke-width="2"/>
+  <rect x="52" y="52" width="78" height="18" rx="9" fill="#1A4B7A"/>
+  <rect x="52" y="82" width="216" height="10" rx="5" fill="#D6E0EA"/>
+  <rect x="52" y="100" width="182" height="10" rx="5" fill="#D6E0EA"/>
+  <rect x="206" y="116" width="62" height="18" rx="9" fill="#1A4B7A"/>
+  <path d="M200 56H230V86H200V56Z" fill="#E7EEF5"/>
+  <path d="M214 44V98" stroke="#1A4B7A" stroke-width="6" stroke-linecap="round"/>
+  <path d="M186 71H242" stroke="#1A4B7A" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/studio/static/page-builder/upcomingEvents.svg
+++ b/studio/static/page-builder/upcomingEvents.svg
@@ -1,0 +1,18 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F2F6FA"/>
+  <rect x="26" y="34" width="78" height="110" rx="12" fill="#FFFFFF" stroke="#CBD8E3" stroke-width="2"/>
+  <rect x="121" y="34" width="78" height="110" rx="12" fill="#FFFFFF" stroke="#CBD8E3" stroke-width="2"/>
+  <rect x="216" y="34" width="78" height="110" rx="12" fill="#FFFFFF" stroke="#CBD8E3" stroke-width="2"/>
+  <rect x="40" y="48" width="18" height="18" rx="4" fill="#F0A429"/>
+  <rect x="135" y="48" width="18" height="18" rx="4" fill="#F0A429"/>
+  <rect x="230" y="48" width="18" height="18" rx="4" fill="#F0A429"/>
+  <rect x="40" y="76" width="44" height="10" rx="5" fill="#193B63"/>
+  <rect x="135" y="76" width="44" height="10" rx="5" fill="#193B63"/>
+  <rect x="230" y="76" width="44" height="10" rx="5" fill="#193B63"/>
+  <rect x="40" y="96" width="50" height="8" rx="4" fill="#D4DFE9"/>
+  <rect x="135" y="96" width="50" height="8" rx="4" fill="#D4DFE9"/>
+  <rect x="230" y="96" width="50" height="8" rx="4" fill="#D4DFE9"/>
+  <rect x="40" y="114" width="30" height="14" rx="7" fill="#193B63"/>
+  <rect x="135" y="114" width="30" height="14" rx="7" fill="#193B63"/>
+  <rect x="230" y="114" width="30" height="14" rx="7" fill="#193B63"/>
+</svg>

--- a/studio/static/page-builder/zundfolgeLatest.svg
+++ b/studio/static/page-builder/zundfolgeLatest.svg
@@ -1,0 +1,12 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="18" fill="#F5F7FA"/>
+  <rect x="30" y="26" width="84" height="128" rx="12" fill="#193B63"/>
+  <rect x="42" y="40" width="60" height="72" rx="8" fill="#9EB4C9"/>
+  <rect x="44" y="118" width="40" height="8" rx="4" fill="#FFFFFF"/>
+  <rect x="44" y="132" width="52" height="8" rx="4" fill="#D6E0EA"/>
+  <rect x="134" y="40" width="132" height="14" rx="7" fill="#193B63"/>
+  <rect x="134" y="66" width="126" height="10" rx="5" fill="#C9D6E2"/>
+  <rect x="134" y="84" width="118" height="10" rx="5" fill="#C9D6E2"/>
+  <rect x="134" y="102" width="122" height="10" rx="5" fill="#C9D6E2"/>
+  <rect x="134" y="126" width="66" height="18" rx="9" fill="#F0A429"/>
+</svg>


### PR DESCRIPTION
This pull request introduces a custom visual section picker for the page builder in the Sanity Studio. The main change is the addition of a new `PageBuilderInput` React component, which provides a more user-friendly way to add and preview page sections, and its integration into the page document schema.

**Enhancements to the page builder experience:**

* Added a new `PageBuilderInput` React component that displays a dialog with visual previews and descriptions for each available section type, allowing users to easily select and insert sections into a page. (`studio/src/components/PageBuilderInput.jsx`)
* Updated the `page` document schema to use the new `PageBuilderInput` as the custom input component for the `sections` array field, improving the workflow for adding and managing page sections. (`studio/schemas/documents/page.js`) [[1]](diffhunk://#diff-850bf920b0fd8741227b429fec95be752ea09a5a8397983f58223796ae4c2ee4R2) [[2]](diffhunk://#diff-850bf920b0fd8741227b429fec95be752ea09a5a8397983f58223796ae4c2ee4R23-R25)